### PR TITLE
♻️ Add GROUP BY clause (+ tests)

### DIFF
--- a/src/Clauses/Clause.php
+++ b/src/Clauses/Clause.php
@@ -241,4 +241,15 @@ abstract class Clause
         return $this->statement
             ->fetchAll(...$args);
     }
+
+    protected static function isAssociativeArray($subject): bool
+    {
+        if (!is_array($subject))
+            return false;
+
+        foreach (array_keys($subject) as $key)
+            if (!is_string($key))
+                return false;
+        return true;
+    }
 }

--- a/src/Clauses/Delete.php
+++ b/src/Clauses/Delete.php
@@ -4,8 +4,9 @@ namespace Ludal\QueryBuilder\Clauses;
 
 use Ludal\QueryBuilder\Exceptions\InvalidQueryException;
 
-class Delete extends WhereClause
+class Delete extends Clause
 {
+    use Where;
 
     public function validate(): void
     {

--- a/src/Clauses/GroupBy.php
+++ b/src/Clauses/GroupBy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Ludal\QueryBuilder\Clauses;
+
+use InvalidArgumentException;
+
+trait GroupBy
+{
+    protected $groupByColumns;
+
+    /**
+     * Add a select groupByColumn (GROUP BY clause). The groupByColumns can be as strings
+     * or associative array.
+     * 
+     * @param ...$groupByColumns the groupByColumn
+     * @throws InvalidArgumentException if any groupByColumn is not a string/array
+     */
+    public function groupBy(...$groupByColumns)
+    {
+        foreach ($groupByColumns as $groupByColumn) {
+            if (self::isAssociativeArray($groupByColumn)) {
+                $conds = [];
+
+                foreach ($groupByColumn as $key => $value) {
+                    $conds[] = "$key $value";
+                    $this->setParam($key, $value);
+                }
+
+                return $this->groupBy(...$conds);
+            }
+            if (!is_string($groupByColumn))
+                throw new InvalidArgumentException('groupByColumns must be strings');
+        }
+
+        if ($groupByColumns)
+            $this->groupByColumns[] = implode(', ', $groupByColumns);
+
+        return $this;
+    }
+
+    /**
+     * Convert the current GROUP BY into a SQL string
+     */
+    protected function groupByToSQL(): string
+    {
+        $groupByColumns = implode(', ', $this->groupByColumns);
+        return "GROUP BY $groupByColumns";
+    }
+}

--- a/src/Clauses/Select.php
+++ b/src/Clauses/Select.php
@@ -5,8 +5,11 @@ namespace Ludal\QueryBuilder\Clauses;
 use InvalidArgumentException;
 use Ludal\QueryBuilder\Exceptions\InvalidQueryException;
 
-class Select extends WhereClause
+class Select extends Clause
 {
+    use Where;
+    use GroupBy;
+
     /**
      * @var array the columns to select
      */
@@ -171,6 +174,9 @@ class Select extends WhereClause
 
         if ($this->conditions)
             $sql .= ' ' . $this->whereToSQL();
+
+        if ($this->groupByColumns)
+            $sql .= ' ' . $this->groupByToSQL();
 
         if ($this->order)
             $sql .= " ORDER BY " . implode(', ', $this->order);

--- a/src/Clauses/Update.php
+++ b/src/Clauses/Update.php
@@ -4,8 +4,10 @@ namespace Ludal\QueryBuilder\Clauses;
 
 use Ludal\QueryBuilder\Exceptions\InvalidQueryException;
 
-class Update extends WhereClause
+class Update extends Clause
 {
+    use Where;
+
     /**
      * @var array the params, in the form : "id = 4", "age = 20"...
      */

--- a/src/Clauses/Where.php
+++ b/src/Clauses/Where.php
@@ -3,9 +3,8 @@
 namespace Ludal\QueryBuilder\Clauses;
 
 use InvalidArgumentException;
-use Ludal\QueryBuilder\Clauses\Clause;
 
-abstract class WhereClause extends Clause
+trait Where
 {
     protected $conditions;
 
@@ -58,16 +57,5 @@ abstract class WhereClause extends Clause
     {
         $conditions = implode(') OR (', $this->conditions);
         return "WHERE ($conditions)";
-    }
-
-    private static function isAssociativeArray($subject): bool
-    {
-        if (!is_array($subject))
-            return false;
-
-        foreach (array_keys($subject) as $key)
-            if (!is_string($key))
-                return false;
-        return true;
     }
 }

--- a/tests/Clauses/SelectTest.php
+++ b/tests/Clauses/SelectTest.php
@@ -180,6 +180,43 @@ final class SelectTest extends TestCase
         $this->assertEquals($expected, $sql);
     }
 
+    public function testQueryWithGroupByClause()
+    {
+        $sql = $this->builder
+            ->setColumns('COUNT(*)')
+            ->from('users')
+            ->groupBy('group_id')
+            ->toSQL();
+
+        $this->assertEquals('SELECT COUNT(*) FROM users GROUP BY group_id', $sql);
+    }
+
+    public function testQueryWithMultipleGroupByClauses()
+    {
+        $sql = $this->builder
+            ->setColumns('COUNT(*)')
+            ->from('users')
+            ->groupBy('group_id', 'second_group_id')
+            ->toSQL();
+
+        $expected = 'SELECT COUNT(*) FROM users GROUP BY group_id, second_group_id';
+
+        $this->assertEquals($expected, $sql);
+    }
+
+    public function testGroupByAsAssociativeArray()
+    {
+        $sql = $this->builder
+            ->setColumns('COUNT(*)')
+            ->from('users')
+            ->groupBy(['group_id' => 'ASC', 'second_group_id' => 'DESC'])
+            ->toSQL();
+
+        $expected = 'SELECT COUNT(*) FROM users GROUP BY group_id ASC, second_group_id DESC';
+
+        $this->assertEquals($expected, $sql);
+    }
+
     public function testOrderBy()
     {
         $sql = $this->builder


### PR DESCRIPTION
This PR applies a minor change in the structure of the program. `WHERE` and `GROUP BY` clauses are now implemented in traits.

Resolves #5.